### PR TITLE
Cache Environment and accept extra initialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Pass the jinja2 loader instance to the "template_loader" parameter which for "to
 ```python
 import tornado.web
 
-jinja2loader = Jinja2Loader('templates_path')
-settings = dict(template_loader=jinja2loader)
+jinja2_env = jinja2.Environment()
+jinja2_env.loader = jinja2.FileSystemLoader('/path/to/templates')
+jinja2_loader = Jinja2Loader(jinja2_env)
+settings = dict(template_loader=jinja2_loader)
 
 application = tornado.web.Application(handler=[],
                                       **settings)

--- a/test/test.py
+++ b/test/test.py
@@ -8,7 +8,8 @@ import jinja2
 class LoaderTest(unittest.TestCase):
     def setUp(self):
         templates_path = 'test/templates/'
-        self.template_obj = Jinja2Loader(templates_path).load('page.html')
+        self.loader = Jinja2Loader(templates_path, jinja2_env_options={'newline_sequence': '\r\n'})
+        self.template_obj = self.loader.load('page.html')
 
     def test_load_template(self):
         self.assertIsInstance(self.template_obj, jinja2.Template)
@@ -16,6 +17,16 @@ class LoaderTest(unittest.TestCase):
     def test_generete_html(self):
         html_code = self.template_obj.generate(name='hi')
         self.assertIn('hi', html_code)
+
+    def test_get_jinja2_environment(self):
+        self.assertEqual(self.template_obj.environment, self.loader.get_jinja2_environment())
+
+    def test_cached_jinja2_environment(self):
+        template_obj2 = self.loader.load('page.html')
+        self.assertEqual(self.template_obj.environment, template_obj2.environment)
+
+    def test_jinja2_env_options(self):
+        self.assertEqual(self.loader.get_jinja2_environment().newline_sequence, '\r\n')
 
 
 if __name__ == '__main__':

--- a/tornado_jinja2/integration.py
+++ b/tornado_jinja2/integration.py
@@ -15,26 +15,67 @@ class FixedTemplate(jinja2.Template):
 Environment.template_class = FixedTemplate
 
 
-class Jinja2Loader(tornado.template.Loader):
-    """ inherit form tornado.template.Loader
+class Jinja2Loader(tornado.template.BaseLoader):
+    """ inherit form tornado.template.BaseLoader
     Implementing customized Template Loader of for tornado to generate
     Jinja2 template.
 
-    A dictionary may be passed using `jinja2_env_options` parameter, which
-    will be used as keyword arguments to create the Jinja2's Environment object.
-    Additional arguments are passed to tornado.template.Loader.
+    A jinja2.environment.Environment object may be provided using
+    `jinja2_environment` argument, it can also be set later using `jinja2_environment`
+    property. Additional arguments are passed to tornado.template.BaseLoader.
+
+    A very basic example for a loader that looks up templates on the file
+    system could look like this::
+
+        jinja2_environment = jinja2.Environment()
+        jinja2_environment.loader = jinja2.FileSystemLoader('/path/to/templates')
+        loader = Jinja2Loader(jinja2_environment)
     """
 
-    def __init__(self, root_directory, **kwargs):
-        env_options = kwargs.pop('jinja2_env_options') or {}
+    def __init__(self, *args, **kwargs):
+        # Get arguments with backward compatibility
+        if args:
+            arg = args[0]
+            if isinstance(arg, Environment):
+                jinja2_environment = arg
+                root_directory = None
+            else:
+                jinja2_environment = None
+                root_directory = args
+            kwargs.pop('jinja2_environment', None)
+            kwargs.pop('root_directory', None)
+        else:
+            jinja2_environment = kwargs.pop('jinja2_environment', None)
+            root_directory = kwargs.pop('root_directory', None)
 
-        super(Jinja2Loader, self).__init__(root_directory, **kwargs)
+        if jinja2_environment:  # Env provided
+            self._jinja2_env = jinja2_environment
+        elif root_directory:  # Backward compatibility
+            self._jinja2_env = Environment()
+            self._jinja2_env.loader = FileSystemLoader(root_directory)
+        else:  # Set env later
+            self._jinja2_env = None
 
-        env_options['loader'] = FileSystemLoader(self.root)
-        self._jinja2_env = Environment(**env_options)
+        super(Jinja2Loader, self).__init__(**kwargs)
 
-    def get_jinja2_environment(self):
+    @property
+    def jinja2_environment(self):
         return self._jinja2_env
 
+    @jinja2_environment.setter
+    def jinja2_environment(self, env):
+        if env is self._jinja2_env:
+            return
+
+        # Clear template cache
+        with self.lock:
+            self._jinja2_env = env
+            self.templates = {}
+
+    def resolve_path(self, name, parent_path=None):
+        return name  #
+
     def _create_template(self, name):
+        if self._jinja2_env is None:
+            raise TypeError('no jinja2 environment for this loader specified')
         return self._jinja2_env.get_template(name)

--- a/tornado_jinja2/integration.py
+++ b/tornado_jinja2/integration.py
@@ -73,7 +73,7 @@ class Jinja2Loader(tornado.template.BaseLoader):
             self.templates = {}
 
     def resolve_path(self, name, parent_path=None):
-        return name  #
+        return name  # Template searching should be handled by Jinja2's loader
 
     def _create_template(self, name):
         if self._jinja2_env is None:

--- a/tornado_jinja2/integration.py
+++ b/tornado_jinja2/integration.py
@@ -17,10 +17,24 @@ Environment.template_class = FixedTemplate
 
 class Jinja2Loader(tornado.template.Loader):
     """ inherit form tornado.template.Loader
-    Implementing customized Template Loader of for tornado to generate\
-            jinja2 template
-    """
-    def _create_template(self, name):
-        env = Environment(loader=FileSystemLoader(self.root))
-        return env.get_template(name)
+    Implementing customized Template Loader of for tornado to generate
+    Jinja2 template.
 
+    A dictionary may be passed using `jinja2_env_options` parameter, which
+    will be used as keyword arguments to create the Jinja2's Environment object.
+    Additional arguments are passed to tornado.template.Loader.
+    """
+
+    def __init__(self, root_directory, **kwargs):
+        env_options = kwargs.pop('jinja2_env_options') or {}
+
+        super(Jinja2Loader, self).__init__(root_directory, **kwargs)
+
+        env_options['loader'] = FileSystemLoader(self.root)
+        self._jinja2_env = Environment(**env_options)
+
+    def get_jinja2_environment(self):
+        return self._jinja2_env
+
+    def _create_template(self, name):
+        return self._jinja2_env.get_template(name)


### PR DESCRIPTION
This PR makes a `Jinja2Loader` object use a single `Environment` object while creating templates. And an extra keyword parameter `jinja2_env_options` was added, which accept a dictionary and will be used as keyword arguments to create the Jinja2' `Environment` object.
